### PR TITLE
Add support for passing a function to update state

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,8 +17,9 @@ export default function useState<T>(
   const actualVals = stores[name] === undefined ? store : stores[name];
   stores[name] = actualVals;
 
-  const update = (newState: T) => {
-    stores[name] = newState;
+  const update = (newState: T | (oldState: T) => T) => {
+    const newVal = typeof newState === "function" ? newState(stores[name]) : newState;
+    stores[name] = newVal;
     addons.getChannel().emit(FORCE_RE_RENDER);
   };
   update.toString = () => `set${capitalizeFirstLetter(name)}(newState)`;


### PR DESCRIPTION
In React, you can do this:

```ts
const [myState, setMyState] = useState<string[]>(["hello"]);

setMyState(prevVal => [...prevVal, "world"]);
```

whereas currently in storybook-addon-state you can only do

```ts
const [myState, setMyState] = useState<string[]>(["hello"]);

setMyState(["hello", "world"]);
```

This PR proposes adding support for the former 😄