### PR TITLE
Updated addon to Storybook 7 standard

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "url": "https://github.com/adierkens/storybook-addon-state.git"
   },
   "devDependencies": {
-    "@storybook/addons": "~5.0.1",
-    "@storybook/core-events": "~5.0.1",
+    "@storybook/addons": "~7.0.17",
+    "@storybook/core-events": "~7.0.17",
     "@types/react": "^16.8.8",
     "ava": "~1.3.1",
     "husky": "~1.3.1",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import addons from '@storybook/addons';
+import { addons } from '@storybook/preview-api';
 import { FORCE_RE_RENDER, STORY_CHANGED } from '@storybook/core-events';
 
 let stores: Record<string, any> = {};


### PR DESCRIPTION
Storybook 7 changed the addon API and moved the addons export to @storybook/preview-api.